### PR TITLE
Fix the injection of "50" using ydotool

### DIFF
--- a/src/text_injector.py
+++ b/src/text_injector.py
@@ -168,11 +168,11 @@ class TextInjector:
         return processed
 
     def _inject_via_ydotool(self, text: str) -> bool:
-        """Inject text using ydotool with --delay 50 and raw text (no escaping)"""
+        """Inject text using ydotool with --key-delay 50 and raw text (no escaping)"""
         try:
-            cmd = ['ydotool', 'type', '--delay', '50', text]
+            cmd = ['ydotool', 'type', '--key-delay', '50', text]
             
-            print(f"Injecting text with ydotool: ydotool type --delay 50 [text]")
+            print(f"Injecting text with ydotool: ydotool type --key-delay 50 [text]")
 
             # Run the command
             result = subprocess.run(


### PR DESCRIPTION
When using text_injection.py to inject text, it will insert "50" at the start of every injection. I found that "--delay" is not a valid flag for ydotool. I assume the desired flag is[`--key-delay`](https://man.archlinux.org/man/ydotool.1). [`--delay` is only valid for the xorg xdotool](https://manpages.ubuntu.com/manpages/trusty/man1/xdotool.1.html).
