### PR TITLE
Characters Per Minute setting

### DIFF
--- a/main.py
+++ b/main.py
@@ -662,10 +662,13 @@ class SettingsDialog:
             selected_keyboard_index = self.keyboard_options.index(self.keyboard_device_var.get())
             selected_keyboard_path = self.keyboard_values[selected_keyboard_index]
 
+            # Preform validation
+            typing_speed = self.text_injector.validate_typing_speed(self.typing_speed_var.get())
+
             # Update all settings in config
             self.config.set_setting('primary_shortcut', new_shortcut)
             self.config.set_setting('always_on_top', self.always_on_top_var.get())
-            self.config.set_setting('typing_speed', self.typing_speed_var.get())
+            self.config.set_setting('typing_speed', typing_speed)
             self.config.set_setting('use_clipboard', self.use_clipboard_var.get())
             self.config.set_setting('keyboard_device', selected_keyboard_path)
 
@@ -717,6 +720,9 @@ class SettingsDialog:
             # Call the update callback to refresh main window display
             if self.update_callback:
                 self.update_callback()
+
+            # Apply changes
+            self.text_injector.set_typing_speed(typing_speed)
 
             # Close the dialog (settings saved successfully)
             self._close_dialog()

--- a/src/text_injector.py
+++ b/src/text_injector.py
@@ -168,11 +168,11 @@ class TextInjector:
         return processed
 
     def _inject_via_ydotool(self, text: str) -> bool:
-        """Inject text using ydotool with --delay 50 and raw text (no escaping)"""
+        """Inject text using ydotool with --key-delay 50 and raw text (no escaping)"""
         try:
-            cmd = ['ydotool', 'type', '--delay', '50', text]
+            cmd = ['ydotool', 'type', '--key-delay', '50', text]
             
-            print(f"Injecting text with ydotool: ydotool type --delay 50 [text]")
+            print(f"Injecting text with ydotool: ydotool type --key-delay 50 [text]")
 
             # Run the command
             result = subprocess.run(

--- a/src/text_injector.py
+++ b/src/text_injector.py
@@ -168,11 +168,14 @@ class TextInjector:
         return processed
 
     def _inject_via_ydotool(self, text: str) -> bool:
-        """Inject text using ydotool with --key-delay 50 and raw text (no escaping)"""
+        """Inject text using ydotool using raw text (no escaping)"""
         try:
-            cmd = ['ydotool', 'type', '--key-delay', '50', text]
+            milliseconds_in_minute = 60000
+            desired_delay = milliseconds_in_minute / self.typing_speed
+
+            cmd = ['ydotool', 'type', '--key-delay', str(desired_delay), text]
             
-            print(f"Injecting text with ydotool: ydotool type --key-delay 50 [text]")
+            print(f"Injecting text with ydotool: ydotool type --key-delay "+ str(desired_delay) +" [text]")
 
             # Run the command
             result = subprocess.run(
@@ -244,11 +247,17 @@ class TextInjector:
         except Exception as e:
             print(f"ERROR: Clipboard injection failed: {e}")
             return False
+            
+    def set_typing_speed(self, cpm: int):
+        """Applies the typing speed CPM"""
+        self.typing_speed = cpm
+        print(f"Typing speed set to {self.typing_speed} CPM")
 
-    def set_typing_speed(self, wpm: int):
-        """Set the typing speed in words per minute (10-200 WPM)"""
-        self.typing_speed = max(10, min(200, wpm))
-        print(f"Typing speed set to {self.typing_speed} WPM")
+    def validate_typing_speed(self, cpm: int):
+        """Validates a desired CPM value and returns a value that is clamped between a desired value"""
+        max_speed = 2000
+        min_speed = 10
+        return max(min_speed, min(cpm, max_speed))
 
     def set_use_clipboard_fallback(self, use_clipboard: bool):
         """Enable or disable clipboard fallback"""


### PR DESCRIPTION
When toying with #1 I found the typing speed to be very slow. I tried to adjust the speed using the setting "Typing Speed" which says it is the characters per minute, but changing this value didn't seem to have an impact on speed. From what I can tell, this setting is not actually used in typing. 

This is built on #1 

This PR does a few things:
- Changes the command for ydotool to use a --key-delay based upon the `Typing Speed` setting. 
- Adds validation to the desired CPM. The existing validation would have worked but it seems like it was never actually called?
- Immediately applies the changed CPM value when saving the settings.