### PR TITLE
Add push-to-talk mode for voice recording

### DIFF
--- a/main.py
+++ b/main.py
@@ -184,6 +184,10 @@ class SettingsDialog:
             'Super+X'
         ]
 
+        # Add Alt + letter combinations
+        for letter in 'abcdefghijklmnopqrstuvwxyz':
+            shortcut_options.append(f'Alt+{letter.upper()}')
+
         # Add Ctrl + letter combinations
         for letter in 'abcdefghijklmnopqrstuvwxyz':
             shortcut_options.append(f'Ctrl+{letter.upper()}')
@@ -238,6 +242,19 @@ class SettingsDialog:
             font=("Arial", 9),
         )
         self.test_status_label.pack(side=RIGHT, padx=(10, 0))
+
+        # Push-to-talk mode
+        ptt_frame = ttk.Frame(shortcuts_frame)
+        ptt_frame.pack(fill=X, pady=(10, 0))
+
+        self.push_to_talk_var = tk.BooleanVar(value=self.config.get_setting('push_to_talk', False))
+        ptt_check = ttk.Checkbutton(
+            ptt_frame,
+            text="Push-to-talk (hold key to record, release to stop)",
+            variable=self.push_to_talk_var,
+            bootstyle="round-toggle"
+        )
+        ptt_check.pack(anchor=W)
 
     def _create_model_section(self, parent):
         """Create the model configuration section"""
@@ -676,6 +693,7 @@ class SettingsDialog:
             self.config.set_setting('always_on_top', self.always_on_top_var.get())
             self.config.set_setting('use_clipboard', self.use_clipboard_var.get())
             self.config.set_setting('keyboard_device', selected_keyboard_path)
+            self.config.set_setting('push_to_talk', self.push_to_talk_var.get())
 
             # Update model setting if changed
             new_model = self.model_var.get()
@@ -717,6 +735,10 @@ class SettingsDialog:
                     else:
                         print(f"Successfully activated new shortcut: {new_shortcut}")
                         shortcut_update_success = True
+
+            # Apply push-to-talk mode (update callbacks on shortcuts instance)
+            if self.app_instance:
+                self.app_instance._apply_shortcut_mode()
 
             # Update the current shortcut display in the dialog
             if self.current_shortcut_label:
@@ -1194,16 +1216,30 @@ class WhisperTuxApp:
             from src.global_shortcuts import GlobalShortcuts
             keyboard_device = self.config.get_setting('keyboard_device', '')
             device_path = keyboard_device if keyboard_device else None
+            push_to_talk = self.config.get_setting('push_to_talk', False)
 
             self.global_shortcuts = GlobalShortcuts(
                 primary_key=self.config.get_setting('primary_shortcut', 'F12'),
-                callback=self._toggle_recording,
+                callback=self._start_recording if push_to_talk else self._toggle_recording,
+                release_callback=self._stop_recording if push_to_talk else None,
                 device_path=device_path
             )
             self.global_shortcuts.start()
-            print(f"Global shortcuts initialized")
+            print(f"Global shortcuts initialized (push_to_talk={push_to_talk})")
         except Exception as e:
             print(f"ERROR: Failed to setup global shortcuts: {e}")
+
+    def _apply_shortcut_mode(self):
+        """Update shortcut callbacks when push-to-talk mode changes"""
+        if self.global_shortcuts is None:
+            return
+        push_to_talk = self.config.get_setting('push_to_talk', False)
+        if push_to_talk:
+            self.global_shortcuts.set_callback(self._start_recording)
+            self.global_shortcuts.set_release_callback(self._stop_recording)
+        else:
+            self.global_shortcuts.set_callback(self._toggle_recording)
+            self.global_shortcuts.set_release_callback(None)
             # Still allow the app to run without global shortcuts
 
     def _start_audio_monitor(self):

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -23,7 +23,8 @@ class ConfigManager:
             'always_on_top': True,
             'theme': 'darkly',
             'audio_device': None,  # None means use system default
-            'word_overrides': {}  # Dictionary of word replacements: {"original": "replacement"}
+            'word_overrides': {},  # Dictionary of word replacements: {"original": "replacement"}
+            'push_to_talk': False  # Hold key to record, release to stop
         }
         
         # Set up config directory and file path

--- a/src/global_shortcuts.py
+++ b/src/global_shortcuts.py
@@ -15,22 +15,24 @@ from evdev import InputDevice, categorize, ecodes
 class GlobalShortcuts:
     """Handles global keyboard shortcuts using evdev for hardware-level capture"""
     
-    def __init__(self, primary_key: str = '<f12>', callback: Optional[Callable] = None, device_path: Optional[str] = None):
+    def __init__(self, primary_key: str = '<f12>', callback: Optional[Callable] = None, release_callback: Optional[Callable] = None, device_path: Optional[str] = None):
         self.primary_key = primary_key
         self.callback = callback
+        self.release_callback = release_callback
         self.selected_device_path = device_path
-        
+
         # Device and event handling
         self.devices = []
         self.device_fds = {}
         self.listener_thread = None
         self.is_running = False
         self.stop_event = threading.Event()
-        
+
         # State tracking
         self.pressed_keys = set()
         self.last_trigger_time = 0
         self.debounce_time = 0.5  # 500ms debounce to prevent double triggers
+        self.combination_active = False  # True while shortcut keys are held down
         
         # Parse the primary key combination
         self.target_keys = self._parse_key_combination(primary_key)
@@ -226,24 +228,29 @@ class GlobalShortcuts:
         """Process individual keyboard events"""
         if event.type == ecodes.EV_KEY:
             key_event = categorize(event)
-            
+
             if key_event.keystate == key_event.key_down:
                 # Key pressed
                 self.pressed_keys.add(event.code)
                 self._check_shortcut_combination()
-                
+
             elif key_event.keystate == key_event.key_up:
                 # Key released
                 self.pressed_keys.discard(event.code)
+                # If the combination was active and a target key was released, fire release callback
+                if self.combination_active and event.code in self.target_keys:
+                    self.combination_active = False
+                    self._trigger_release_callback()
     
     def _check_shortcut_combination(self):
         """Check if current pressed keys match target combination"""
         if self.target_keys.issubset(self.pressed_keys):
             current_time = time.time()
-            
+
             # Implement debouncing
             if current_time - self.last_trigger_time > self.debounce_time:
                 self.last_trigger_time = current_time
+                self.combination_active = True
                 self._trigger_callback()
     
     def _trigger_callback(self):
@@ -256,6 +263,16 @@ class GlobalShortcuts:
                 callback_thread.start()
             except Exception as e:
                 print(f"Error calling shortcut callback: {e}")
+
+    def _trigger_release_callback(self):
+        """Trigger the release callback function (for push-to-talk mode)"""
+        if self.release_callback:
+            try:
+                print(f"Global shortcut released: {self.primary_key}")
+                callback_thread = threading.Thread(target=self.release_callback, daemon=True)
+                callback_thread.start()
+            except Exception as e:
+                print(f"Error calling shortcut release callback: {e}")
     
     def start(self) -> bool:
         """Start listening for global shortcuts"""
@@ -301,6 +318,7 @@ class GlobalShortcuts:
             
             self.is_running = False
             self.pressed_keys.clear()
+            self.combination_active = False
             
         except Exception as e:
             print(f"Error stopping global shortcuts: {e}")
@@ -312,6 +330,10 @@ class GlobalShortcuts:
     def set_callback(self, callback: Callable):
         """Set the callback function for shortcut activation"""
         self.callback = callback
+
+    def set_release_callback(self, release_callback: Optional[Callable]):
+        """Set the callback function for shortcut release (push-to-talk mode)"""
+        self.release_callback = release_callback
     
     def update_shortcut(self, new_key: str) -> bool:
         """Update the shortcut key combination"""


### PR DESCRIPTION
When enabled, holding the shortcut key starts recording and releasing it automatically stops recording and triggers transcription. Toggle mode (original behavior) remains the default. Added ALT+letter shortcuts.

- GlobalShortcuts: add release_callback, track combination_active state
- ConfigManager: add push_to_talk setting (default: false)
- main.py: add PTT mode switch in settings dialog and apply callbacks