### PR TITLE
fix(ydotoold): socket permissions on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,17 @@ If you see `failed to open uinput device` errors, run the fix script:
 ./scripts/fix-uinput-permissions.sh
 ```
 
-This script will:
+If you see `failed to connect socket` errors such as
+`/tmp/.ydotool_socket: Permission denied` or
+`$XDG_RUNTIME_DIR/.ydotool_socket: No such file or directory`, reinstall and
+restart the WhisperTux `ydotoold` service so the daemon and client use an
+accessible socket:
+
+```bash
+./scripts/setup-ydotoold-service.sh
+```
+
+The uinput fix script will:
 
 - Add your user to the `input` and `tty` groups
 - Create the necessary udev rule for `/dev/uinput` access
@@ -156,7 +166,7 @@ sudo systemctl restart ydotoold  # if needed
 Test text injection directly:
 
 ```bash
-ydotool type "test message"
+YDOTOOL_SOCKET=/tmp/.ydotool_socket ydotool type "test message"
 ```
 
 ### Whisper Model Issues

--- a/scripts/setup-ydotoold-service.sh
+++ b/scripts/setup-ydotoold-service.sh
@@ -6,7 +6,10 @@
 set -e
 
 SERVICE_NAME="ydotoold"
-SERVICE_FILE="systemd/ydotoold.service"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SERVICE_FILE="$PROJECT_ROOT/systemd/ydotoold.service"
+WRAPPER_FILE="$PROJECT_ROOT/scripts/ydotoold-wrapper.sh"
 SYSTEM_SERVICE_DIR="/etc/systemd/system"
 
 echo "WhisperTux - Setting up ydotoold system service"
@@ -31,24 +34,16 @@ fi
 # Check if service file exists
 if [ ! -f "$SERVICE_FILE" ]; then
     echo "ERROR: Service file not found: $SERVICE_FILE"
-    echo "   Please ensure you're running this from the WhisperTux project directory"
     exit 1
-fi
-
-# Stop any existing ydotoold processes
-if pgrep -x "ydotoold" > /dev/null; then
-    echo "Stopping existing ydotoold processes..."
-    sudo pkill ydotoold || true
-    sleep 1
 fi
 
 # Copy wrapper script to system location
 echo "Installing ydotoold wrapper script..."
-if [ -f "scripts/ydotoold-wrapper.sh" ]; then
-    sudo cp "scripts/ydotoold-wrapper.sh" "/usr/local/bin/"
+if [ -f "$WRAPPER_FILE" ]; then
+    sudo cp "$WRAPPER_FILE" "/usr/local/bin/"
     sudo chmod +x "/usr/local/bin/ydotoold-wrapper.sh"
 else
-    echo "ERROR: Wrapper script not found: scripts/ydotoold-wrapper.sh"
+    echo "ERROR: Wrapper script not found: $WRAPPER_FILE"
     exit 1
 fi
 
@@ -60,9 +55,20 @@ sudo cp "$SERVICE_FILE" "$SYSTEM_SERVICE_DIR/"
 echo "Reloading systemd daemon..."
 sudo systemctl daemon-reload
 
+# Stop any old package-provided service before starting the corrected unit.
+echo "Stopping existing ydotoold service/processes..."
+sudo systemctl stop "$SERVICE_NAME" || true
+if YDOTOOLD_PIDS="$(pgrep -x ydotoold || true)" && [ -n "$YDOTOOLD_PIDS" ]; then
+    echo "$YDOTOOLD_PIDS" | xargs -r sudo kill
+    sleep 1
+fi
+
 # Enable the service
 echo "Enabling ydotoold service..."
 sudo systemctl enable "$SERVICE_NAME"
+
+# Clear any previous start-limit failure before starting the corrected unit.
+sudo systemctl reset-failed "$SERVICE_NAME" || true
 
 # Start the service
 echo "Starting ydotoold service..."
@@ -82,7 +88,7 @@ if pgrep -x "ydotoold" > /dev/null; then
 else
     echo ""
     echo "ERROR: ydotoold service failed to start"
-    echo "Check the service logs: sudo systemctl logs $SERVICE_NAME"
+    echo "Check the service logs: sudo journalctl -u $SERVICE_NAME --no-pager -n 100"
     exit 1
 fi
 
@@ -91,6 +97,6 @@ echo "Service management commands (run as root/sudo):"
 echo "   Start:   sudo systemctl start $SERVICE_NAME"
 echo "   Stop:    sudo systemctl stop $SERVICE_NAME"
 echo "   Status:  sudo systemctl status $SERVICE_NAME"
-echo "   Logs:    sudo systemctl logs $SERVICE_NAME"
+echo "   Logs:    sudo journalctl -u $SERVICE_NAME --no-pager -n 100"
 echo "   Restart: sudo systemctl restart $SERVICE_NAME"
 echo ""

--- a/scripts/ydotoold-wrapper.sh
+++ b/scripts/ydotoold-wrapper.sh
@@ -1,23 +1,25 @@
 #!/bin/bash
 
-# Wrapper script for ydotoold to set proper permissions
-# Remove existing socket
-rm -f /tmp/.ydotool_socket
+# Wrapper script for ydotoold to set socket permissions usable by WhisperTux.
+set -euo pipefail
 
-# Start ydotoold in background
-/usr/bin/ydotoold &
-YDOTOOLD_PID=$!
+SOCKET_PATH="${YDOTOOL_SOCKET:-/tmp/.ydotool_socket}"
+SOCKET_GROUP="${YDOTOOLD_SOCKET_GROUP:-input}"
 
-# Wait for socket to be created and fix permissions
-for i in {1..30}; do
-    if [ -S /tmp/.ydotool_socket ]; then
-        chmod 660 /tmp/.ydotool_socket
-        chgrp input /tmp/.ydotool_socket
-        echo "ydotoold: socket permissions fixed (660, group: input)"
-        break
-    fi
-    sleep 0.1
-done
+if ! SOCKET_GID="$(getent group "$SOCKET_GROUP" | cut -d: -f3)"; then
+    echo "ydotoold: group '$SOCKET_GROUP' does not exist" >&2
+    exit 1
+fi
 
-# Wait for ydotoold process to finish
-wait $YDOTOOLD_PID
+if [ -z "$SOCKET_GID" ]; then
+    echo "ydotoold: could not resolve gid for group '$SOCKET_GROUP'" >&2
+    exit 1
+fi
+
+rm -f "$SOCKET_PATH"
+
+# Set ownership at socket creation time so clients never see a root-only socket.
+exec /usr/bin/ydotoold \
+    --socket-path="$SOCKET_PATH" \
+    --socket-perm=0660 \
+    --socket-own="0:$SOCKET_GID"

--- a/src/text_injector.py
+++ b/src/text_injector.py
@@ -6,6 +6,8 @@ Handles injecting transcribed text into other applications using ydotool
 import subprocess
 import time
 import pyperclip
+import os
+from pathlib import Path
 from typing import Optional
 
 
@@ -26,9 +28,12 @@ class TextInjector:
 
         # Check if ydotool is available
         self.ydotool_available = self._check_ydotool()
+        self.ydotool_socket = self._detect_ydotool_socket()
 
         if not self.ydotool_available:
             print("⚠️  ydotool not found - text injection will use clipboard fallback")
+        elif self.ydotool_socket:
+            print(f"Using ydotool socket: {self.ydotool_socket}")
 
     def _check_ydotool(self) -> bool:
         """Check if ydotool is available on the atiystem"""
@@ -40,6 +45,60 @@ class TextInjector:
 
         except:
             return False
+
+    def _detect_ydotool_socket(self) -> Optional[str]:
+        """Find the ydotoold socket used by common package/service setups."""
+        candidates = []
+
+        configured_socket = os.environ.get('YDOTOOL_SOCKET')
+        if configured_socket:
+            candidates.append(configured_socket)
+
+        runtime_dir = os.environ.get('XDG_RUNTIME_DIR')
+        if runtime_dir:
+            candidates.append(str(Path(runtime_dir) / '.ydotool_socket'))
+
+        candidates.append('/tmp/.ydotool_socket')
+
+        for socket_path in candidates:
+            if socket_path and Path(socket_path).exists():
+                return socket_path
+
+        return None
+
+    def _get_ydotool_env(self) -> dict:
+        """Build an environment that points ydotool at the detected daemon socket."""
+        env = os.environ.copy()
+        if self.ydotool_socket and not env.get('YDOTOOL_SOCKET'):
+            env['YDOTOOL_SOCKET'] = self.ydotool_socket
+        return env
+
+    def _log_ydotool_failure(self, result: subprocess.CompletedProcess):
+        """Log enough detail to diagnose ydotool daemon/socket failures."""
+        print(f"ERROR: ydotool failed with exit code {result.returncode}")
+
+        stdout = (result.stdout or '').strip()
+        stderr = (result.stderr or '').strip()
+        if stdout:
+            print(f"ydotool stdout: {stdout}")
+        if stderr:
+            print(f"ydotool stderr: {stderr}")
+        if not stdout and not stderr:
+            print("ydotool did not print any error output")
+
+        socket_path = self.ydotool_socket or os.environ.get('YDOTOOL_SOCKET')
+        if socket_path:
+            socket_file = Path(socket_path)
+            print(f"ydotool socket: {socket_path}")
+            if socket_file.exists():
+                socket_readable = os.access(socket_path, os.R_OK)
+                socket_writable = os.access(socket_path, os.W_OK)
+                print(f"ydotool socket readable={socket_readable} writable={socket_writable}")
+                if not socket_readable or not socket_writable:
+                    print("ydotool socket is not accessible by the current user.")
+                    print("Run: ./scripts/setup-ydotoold-service.sh")
+            else:
+                print("ydotool socket does not exist")
 
     def inject_text(self, text: str) -> bool:
         """
@@ -179,13 +238,14 @@ class TextInjector:
                 cmd,
                 capture_output=True,
                 text=True,
-                timeout=60
+                timeout=60,
+                env=self._get_ydotool_env()
             )
 
             if result.returncode == 0:
                 return True
             else:
-                print(f"ERROR: ydotool failed: {result.stderr}")
+                self._log_ydotool_failure(result)
                 return False
 
         except subprocess.TimeoutExpired:
@@ -216,11 +276,12 @@ class TextInjector:
                 result = subprocess.run(
                     ['ydotool', 'key', '29:1', '47:1', '47:0', '29:0'],
                     capture_output=True,
-                    timeout=5
+                    timeout=5,
+                    env=self._get_ydotool_env()
                 )
 
                 if result.returncode != 0:
-                    print(f"  ydotool paste command failed: {result.stderr}")
+                    self._log_ydotool_failure(result)
             else:
                 print("No method available to send paste command")
                 print("   Text has been copied to clipboard - paste manually with Ctrl+V")


### PR DESCRIPTION
## Summary
- start ydotoold with explicit socket ownership and permissions
- pass the detected ydotool socket path to ydotool commands
- document socket permission and path mismatch troubleshooting

## Why
Some ydotoold installs create /tmp/.ydotool_socket as root-only, while ydotool clients may look under XDG_RUNTIME_DIR by default. That leaves WhisperTux unable to inject text even when ydotoold is running.

## Checks
- bash -n scripts/setup-ydotoold-service.sh
- bash -n scripts/ydotoold-wrapper.sh
- python3 -m py_compile src/text_injector.py
- git diff --cached --check