### PR TITLE
feat(settings):  selectable audio input devices in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Settings are stored in `~/.config/whispertux/config.json`:
 }
 ```
 
+When a microphone is selected in the UI, `audio_device` is saved as a stable
+device reference using the device name and host API so the same source can be
+restored across restarts even if PortAudio device indexes change.
+
 ### Available Models
 
 Any [whisper](https://github.com/openai/whisper) model is usable. By default the

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -244,7 +244,7 @@ Set in configuration:
 
 ```json
 {
-  "audio_device": "default"
+  "audio_device": null
 }
 ```
 

--- a/main.py
+++ b/main.py
@@ -317,6 +317,8 @@ class SettingsDialog:
         """Create the general settings section"""
         general_frame = ttk.LabelFrame(parent, text="General Settings", padding=15)
         general_frame.pack(fill=X, pady=(0, 15))
+        field_label_width = 16
+        selector_width = 35
 
         # Always on top setting
         always_on_top_frame = ttk.Frame(general_frame)
@@ -348,7 +350,7 @@ class SettingsDialog:
         key_delay_frame = ttk.Frame(general_frame)
         key_delay_frame.pack(fill=X, pady=(5, 5))
 
-        ttk.Label(key_delay_frame, text="Key Delay (ms):").pack(side=LEFT)
+        ttk.Label(key_delay_frame, text="Key Delay (ms):", width=field_label_width, anchor=W).pack(side=LEFT)
 
         self.key_delay_var = tk.StringVar(value=str(self.config.get_setting('key_delay', 15)))
         key_delay_entry = ttk.Entry(
@@ -358,33 +360,71 @@ class SettingsDialog:
         )
         key_delay_entry.pack(side=RIGHT)
 
+        # Audio input device selection
+        audio_frame = ttk.Frame(general_frame)
+        audio_frame.pack(fill=X, pady=(5, 5))
+
+        ttk.Label(audio_frame, text="Audio Input:", width=field_label_width, anchor=W).pack(side=LEFT)
+
+        available_audio_devices = []
+        audio_options = ["System Default"]
+        audio_values = [None]
+        try:
+            available_audio_devices = AudioCapture.get_available_input_devices()
+            for device in available_audio_devices:
+                audio_options.append(device['display_name'])
+                audio_values.append(device['id'])
+
+        except Exception as e:
+            print(f"Error getting audio devices: {e}")
+
+        self.audio_device_options = audio_options
+        self.audio_device_values = audio_values
+
+        current_audio_device = AudioCapture.normalize_device_reference(
+            self.config.get_setting('audio_device', None)
+        )
+        current_audio_index = 0
+        if current_audio_device in self.audio_device_values:
+            current_audio_index = self.audio_device_values.index(current_audio_device)
+        elif isinstance(current_audio_device, str):
+            for index, device in enumerate(available_audio_devices, start=1):
+                if current_audio_device in (device['name'], device['display_name']):
+                    current_audio_index = index
+                    break
+
+        self.audio_device_var = tk.StringVar(value=audio_options[current_audio_index])
+        audio_combo = ttk.Combobox(
+            audio_frame,
+            textvariable=self.audio_device_var,
+            values=audio_options,
+            state="readonly",
+            width=selector_width
+        )
+        audio_combo.pack(side=RIGHT)
+
         # Keyboard device selection
         keyboard_frame = ttk.Frame(general_frame)
         keyboard_frame.pack(fill=X, pady=(5, 0))
 
-        ttk.Label(keyboard_frame, text="Keyboard Device:").pack(side=LEFT)
+        ttk.Label(keyboard_frame, text="Keyboard Device:", width=field_label_width, anchor=W).pack(side=LEFT)
 
         # Get available keyboards
+        keyboard_options = ["Auto-detect (All Keyboards)"]
+        keyboard_values = [""]
         try:
             from src.global_shortcuts import get_available_keyboards
             available_keyboards = get_available_keyboards()
-
-            keyboard_options = ["Auto-detect (All Keyboards)"]
-            keyboard_values = [""]
 
             for kb in available_keyboards:
                 keyboard_options.append(kb['display_name'])
                 keyboard_values.append(kb['path'])
 
-            self.keyboard_options = keyboard_options
-            self.keyboard_values = keyboard_values
-
         except Exception as e:
             print(f"Error getting keyboard devices: {e}")
-            keyboard_options = ["Auto-detect (All Keyboards)"]
-            keyboard_values = [""]
-            self.keyboard_options = keyboard_options
-            self.keyboard_values = keyboard_values
+
+        self.keyboard_options = keyboard_options
+        self.keyboard_values = keyboard_values
 
         # Find current selection
         current_device = self.config.get_setting('keyboard_device', '')
@@ -398,7 +438,7 @@ class SettingsDialog:
             textvariable=self.keyboard_device_var,
             values=keyboard_options,
             state="readonly",
-            width=35
+            width=selector_width
         )
         keyboard_combo.pack(side=RIGHT)
 
@@ -680,6 +720,8 @@ class SettingsDialog:
             # Get keyboard device selection
             selected_keyboard_index = self.keyboard_options.index(self.keyboard_device_var.get())
             selected_keyboard_path = self.keyboard_values[selected_keyboard_index]
+            selected_audio_index = self.audio_device_options.index(self.audio_device_var.get())
+            selected_audio_device = self.audio_device_values[selected_audio_index]
 
             # Validate and update key delay setting
             key_delay_str = self.key_delay_var.get().strip()
@@ -693,10 +735,19 @@ class SettingsDialog:
                 messagebox.showwarning("Invalid Input", "Key delay must be a valid number.")
                 return
 
+            if self.app_instance and self.app_instance.audio_capture:
+                if not self.app_instance.audio_capture.set_device(selected_audio_device):
+                    messagebox.showwarning(
+                        "Audio Device Unavailable",
+                        "Failed to switch to the selected audio input. The device may have been disconnected."
+                    )
+                    return
+
             # Update all settings in config
             self.config.set_setting('primary_shortcut', new_shortcut)
             self.config.set_setting('always_on_top', self.always_on_top_var.get())
             self.config.set_setting('use_clipboard', self.use_clipboard_var.get())
+            self.config.set_setting('audio_device', selected_audio_device)
             self.config.set_setting('keyboard_device', selected_keyboard_path)
             self.config.set_setting('push_to_talk', self.push_to_talk_var.get())
 
@@ -826,6 +877,8 @@ class SettingsDialog:
                 self.always_on_top_var.set(self.config.get_setting('always_on_top'))
                 self.key_delay_var.set(str(self.config.get_setting('key_delay')))
                 self.use_clipboard_var.set(self.config.get_setting('use_clipboard'))
+                if hasattr(self, 'audio_device_var'):
+                    self.audio_device_var.set("System Default")
                 self._refresh_model_combo_dialog()
 
                 # Update the current shortcut display in the dialog

--- a/main.py
+++ b/main.py
@@ -373,7 +373,7 @@ class SettingsDialog:
             available_audio_devices = AudioCapture.get_available_input_devices()
             for device in available_audio_devices:
                 audio_options.append(device['display_name'])
-                audio_values.append(device['id'])
+                audio_values.append(device['reference'])
 
         except Exception as e:
             print(f"Error getting audio devices: {e}")
@@ -387,6 +387,20 @@ class SettingsDialog:
         current_audio_index = 0
         if current_audio_device in self.audio_device_values:
             current_audio_index = self.audio_device_values.index(current_audio_device)
+        elif isinstance(current_audio_device, int):
+            for index, device in enumerate(available_audio_devices, start=1):
+                if current_audio_device == device['id']:
+                    current_audio_index = index
+                    break
+        elif isinstance(current_audio_device, dict):
+            for index, device in enumerate(available_audio_devices, start=1):
+                if device['reference']['name'] != current_audio_device.get('name'):
+                    continue
+                saved_host_api = current_audio_device.get('host_api')
+                if saved_host_api and device['reference']['host_api'] != saved_host_api:
+                    continue
+                current_audio_index = index
+                break
         elif isinstance(current_audio_device, str):
             for index, device in enumerate(available_audio_devices, start=1):
                 if current_audio_device in (device['name'], device['display_name']):
@@ -949,8 +963,8 @@ class WhisperTuxApp:
         self.config = ConfigManager()
 
         # Initialize audio capture with configured device
-        audio_device_id = self.config.get_setting('audio_device', None)
-        self.audio_capture = AudioCapture(device_id=audio_device_id)
+        audio_device_reference = self.config.get_setting('audio_device', None)
+        self.audio_capture = AudioCapture(device_reference=audio_device_reference)
 
         self.whisper_manager = WhisperManager()
         self.text_injector = TextInjector(self.config)

--- a/src/audio_capture.py
+++ b/src/audio_capture.py
@@ -9,7 +9,6 @@ import wave
 import threading
 import time
 from typing import Optional, Callable
-from io import BytesIO
 
 
 class AudioCapture:
@@ -44,7 +43,24 @@ class AudioCapture:
         self.stream = None
         
         # Initialize sounddevice
+        self.preferred_device_id = self.normalize_device_reference(self.preferred_device_id)
         self._initialize_sounddevice()
+
+    @staticmethod
+    def normalize_device_reference(device_id):
+        """Normalize config/device selector values into sounddevice-compatible references."""
+        if device_id is None:
+            return None
+
+        if isinstance(device_id, str):
+            normalized = device_id.strip()
+            if not normalized or normalized.lower() == 'default':
+                return None
+            if normalized.lstrip('+-').isdigit():
+                return int(normalized)
+            return normalized
+
+        return device_id
     
     def _initialize_sounddevice(self):
         """Initialize sounddevice and check for available devices"""
@@ -205,10 +221,18 @@ class AudioCapture:
     def set_device(self, device_id):
         """Set the audio input device"""
         try:
+            device_id = self.normalize_device_reference(device_id)
+
             if device_id is None:
                 # Reset to system default
                 self.preferred_device_id = None
                 sd.default.device[0] = None
+                self.device_info = None
+                self.device_id = None
+                self.sample_rate = self.target_sample_rate
+                sd.default.samplerate = self.sample_rate
+                print("Audio device changed to system default input")
+                return True
             else:
                 # Validate device exists and has input channels
                 device_info = sd.query_devices(device=device_id, kind='input')

--- a/src/audio_capture.py
+++ b/src/audio_capture.py
@@ -14,7 +14,7 @@ from typing import Optional, Callable
 class AudioCapture:
     """Handles audio recording and real-time level monitoring"""
     
-    def __init__(self, device_id=None):
+    def __init__(self, device_reference=None):
         # Audio configuration - whisper.cpp prefers 16kHz mono
         self.target_sample_rate = 16000
         self.sample_rate = self.target_sample_rate
@@ -23,7 +23,8 @@ class AudioCapture:
         self.dtype = np.float32
         
         # Device configuration
-        self.preferred_device_id = device_id
+        self.preferred_device = self.normalize_device_reference(device_reference)
+        self.preferred_device_id = None
         
         # Recording state
         self.is_recording = False
@@ -43,24 +44,78 @@ class AudioCapture:
         self.stream = None
         
         # Initialize sounddevice
-        self.preferred_device_id = self.normalize_device_reference(self.preferred_device_id)
         self._initialize_sounddevice()
 
     @staticmethod
-    def normalize_device_reference(device_id):
+    def build_device_reference(device_name, host_api_name):
+        """Build a stable config representation for an input device."""
+        return {
+            'name': device_name,
+            'host_api': host_api_name,
+        }
+
+    @classmethod
+    def normalize_device_reference(cls, device_reference):
         """Normalize config/device selector values into sounddevice-compatible references."""
-        if device_id is None:
+        if device_reference is None:
             return None
 
-        if isinstance(device_id, str):
-            normalized = device_id.strip()
+        if isinstance(device_reference, str):
+            normalized = device_reference.strip()
             if not normalized or normalized.lower() == 'default':
                 return None
             if normalized.lstrip('+-').isdigit():
                 return int(normalized)
             return normalized
 
-        return device_id
+        if isinstance(device_reference, dict):
+            device_name = str(device_reference.get('name', '')).strip()
+            host_api_name = str(device_reference.get('host_api', '')).strip()
+            if device_name:
+                normalized = cls.build_device_reference(device_name, host_api_name)
+                legacy_device_id = cls.normalize_device_reference(device_reference.get('id'))
+                if isinstance(legacy_device_id, int):
+                    normalized['id'] = legacy_device_id
+                return normalized
+            return cls.normalize_device_reference(device_reference.get('id'))
+
+        return device_reference
+
+    @classmethod
+    def _resolve_input_device_reference(cls, device_reference):
+        """Resolve a saved device reference to the current sounddevice input entry."""
+        normalized_reference = cls.normalize_device_reference(device_reference)
+        if normalized_reference is None:
+            return None
+
+        available_devices = cls.get_available_input_devices()
+
+        if isinstance(normalized_reference, int):
+            for device in available_devices:
+                if device['id'] == normalized_reference:
+                    return device
+            return None
+
+        if isinstance(normalized_reference, str):
+            for device in available_devices:
+                if normalized_reference in (device['name'], device['display_name']):
+                    return device
+            return None
+
+        if isinstance(normalized_reference, dict):
+            for device in available_devices:
+                if device['reference']['name'] != normalized_reference['name']:
+                    continue
+                saved_host_api = normalized_reference.get('host_api')
+                if saved_host_api and device['reference']['host_api'] != saved_host_api:
+                    continue
+                return device
+
+            legacy_device_id = normalized_reference.get('id')
+            if isinstance(legacy_device_id, int):
+                return cls._resolve_input_device_reference(legacy_device_id)
+
+        return None
     
     def _initialize_sounddevice(self):
         """Initialize sounddevice and check for available devices"""
@@ -71,22 +126,23 @@ class AudioCapture:
             sd.default.dtype = self.dtype
             
             # Set the preferred device if specified
-            if self.preferred_device_id is not None:
-                try:
-                    # Validate that the device exists and has input channels
-                    device_info = sd.query_devices(device=self.preferred_device_id, kind='input')
-                    if device_info['max_input_channels'] > 0:
-                        sd.default.device[0] = self.preferred_device_id
-                        print(f"Using configured audio device: {device_info['name']} (ID: {self.preferred_device_id})")
-                    else:
-                        print(f"⚠ Configured device {self.preferred_device_id} has no input channels, using default")
-                        self.preferred_device_id = None
-                except Exception as e:
-                    print(f"⚠ Configured audio device {self.preferred_device_id} not available: {e}")
+            if self.preferred_device is not None:
+                resolved_device = self._resolve_input_device_reference(self.preferred_device)
+                if resolved_device:
+                    self.preferred_device = resolved_device['reference']
+                    self.preferred_device_id = resolved_device['id']
+                    sd.default.device[0] = self.preferred_device_id
+                    print(
+                        "Using configured audio device: "
+                        f"{resolved_device['name']} ({resolved_device['host_api']}, ID: {self.preferred_device_id})"
+                    )
+                else:
+                    print(f"⚠ Configured audio device {self.preferred_device!r} not available, using default")
+                    self.preferred_device = None
                     self.preferred_device_id = None
             
             # If no specific device was configured or it failed, use system default
-            if self.preferred_device_id is None:
+            if self.preferred_device is None:
                 self._set_system_default_device()
             
             # Get and display detailed device information
@@ -195,6 +251,7 @@ class AudioCapture:
                         'channels': device['max_input_channels'],
                         'sample_rate': device['default_samplerate'],
                         'host_api': host_api_info['name'],
+                        'reference': AudioCapture.build_device_reference(device['name'], host_api_info['name']),
                         'display_name': f"{device['name']} ({host_api_info['name']})"
                     })
             
@@ -218,13 +275,14 @@ class AudioCapture:
         except:
             return None
     
-    def set_device(self, device_id):
+    def set_device(self, device_reference):
         """Set the audio input device"""
         try:
-            device_id = self.normalize_device_reference(device_id)
+            device_reference = self.normalize_device_reference(device_reference)
 
-            if device_id is None:
+            if device_reference is None:
                 # Reset to system default
+                self.preferred_device = None
                 self.preferred_device_id = None
                 sd.default.device[0] = None
                 self.device_info = None
@@ -233,20 +291,23 @@ class AudioCapture:
                 sd.default.samplerate = self.sample_rate
                 print("Audio device changed to system default input")
                 return True
-            else:
-                # Validate device exists and has input channels
-                device_info = sd.query_devices(device=device_id, kind='input')
-                if device_info['max_input_channels'] > 0:
-                    self.preferred_device_id = device_id
-                    sd.default.device[0] = device_id
-                    self.device_info = device_info
-                    self.device_id = device_id
-                    self._ensure_supported_samplerate()
-                    print(f"Audio device changed to: {device_info['name']} (ID: {device_id})")
-                    return True
-                else:
-                    print(f"Device {device_id} has no input channels")
-                    return False
+
+            resolved_device = self._resolve_input_device_reference(device_reference)
+            if not resolved_device:
+                print(f"Device {device_reference!r} not available")
+                return False
+
+            self.preferred_device = resolved_device['reference']
+            self.preferred_device_id = resolved_device['id']
+            sd.default.device[0] = self.preferred_device_id
+            self.device_info = sd.query_devices(device=self.preferred_device_id, kind='input')
+            self.device_id = self.preferred_device_id
+            self._ensure_supported_samplerate()
+            print(
+                "Audio device changed to: "
+                f"{resolved_device['name']} ({resolved_device['host_api']}, ID: {self.preferred_device_id})"
+            )
+            return True
                     
         except Exception as e:
             print(f"Error setting audio device: {e}")

--- a/tests/test_audio_capture.py
+++ b/tests/test_audio_capture.py
@@ -1,0 +1,77 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+if 'sounddevice' not in sys.modules:
+    mock_sounddevice = types.ModuleType('sounddevice')
+    mock_sounddevice.default = types.SimpleNamespace(
+        device=[None, None],
+        samplerate=None,
+        channels=None,
+        dtype=None,
+    )
+    mock_sounddevice.query_devices = lambda *args, **kwargs: []
+    mock_sounddevice.query_hostapis = lambda *args, **kwargs: {'name': 'mock'}
+    mock_sounddevice.check_input_settings = lambda *args, **kwargs: None
+    mock_sounddevice.InputStream = object
+    mock_sounddevice.PortAudioError = Exception
+    sys.modules['sounddevice'] = mock_sounddevice
+
+from src.audio_capture import AudioCapture
+
+
+class AudioCaptureDeviceSelectionTests(unittest.TestCase):
+    def test_normalize_device_reference_handles_default_and_string_ids(self):
+        self.assertIsNone(AudioCapture.normalize_device_reference(None))
+        self.assertIsNone(AudioCapture.normalize_device_reference(''))
+        self.assertIsNone(AudioCapture.normalize_device_reference(' default '))
+        self.assertEqual(AudioCapture.normalize_device_reference('7'), 7)
+        self.assertEqual(AudioCapture.normalize_device_reference(3), 3)
+        self.assertEqual(
+            AudioCapture.normalize_device_reference('PipeWire ALSA [android-mic]'),
+            'PipeWire ALSA [android-mic]'
+        )
+
+    @patch.object(AudioCapture, '_initialize_sounddevice', autospec=True, return_value=None)
+    def test_set_device_none_switches_back_to_system_default(self, _mock_initialize):
+        capture = AudioCapture(device_id=5)
+
+        with patch('src.audio_capture.sd') as mock_sd:
+            mock_sd.default.device = [5, None]
+            mock_sd.default.samplerate = 48000
+
+            result = capture.set_device('default')
+
+        self.assertTrue(result)
+        self.assertIsNone(capture.preferred_device_id)
+        self.assertIsNone(capture.device_info)
+        self.assertIsNone(capture.device_id)
+        self.assertEqual(capture.sample_rate, capture.target_sample_rate)
+        self.assertIsNone(mock_sd.default.device[0])
+        self.assertEqual(mock_sd.default.samplerate, capture.target_sample_rate)
+
+    @patch.object(AudioCapture, '_initialize_sounddevice', autospec=True, return_value=None)
+    @patch.object(AudioCapture, '_ensure_supported_samplerate', autospec=True, return_value=None)
+    def test_set_device_accepts_stringified_device_ids(self, _mock_samplerate, _mock_initialize):
+        capture = AudioCapture()
+
+        with patch('src.audio_capture.sd') as mock_sd:
+            mock_sd.default.device = [None, None]
+            mock_sd.query_devices.return_value = {
+                'name': 'PipeWire ALSA [android-mic]',
+                'max_input_channels': 1,
+                'default_samplerate': 48000,
+            }
+
+            result = capture.set_device('7')
+
+        self.assertTrue(result)
+        self.assertEqual(capture.preferred_device_id, 7)
+        self.assertEqual(capture.device_id, 7)
+        self.assertEqual(capture.device_info['name'], 'PipeWire ALSA [android-mic]')
+        self.assertEqual(mock_sd.default.device[0], 7)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_audio_capture.py
+++ b/tests/test_audio_capture.py
@@ -22,20 +22,57 @@ from src.audio_capture import AudioCapture
 
 
 class AudioCaptureDeviceSelectionTests(unittest.TestCase):
-    def test_normalize_device_reference_handles_default_and_string_ids(self):
+    def test_normalize_device_reference_handles_default_string_ids_and_stable_refs(self):
         self.assertIsNone(AudioCapture.normalize_device_reference(None))
         self.assertIsNone(AudioCapture.normalize_device_reference(''))
         self.assertIsNone(AudioCapture.normalize_device_reference(' default '))
         self.assertEqual(AudioCapture.normalize_device_reference('7'), 7)
         self.assertEqual(AudioCapture.normalize_device_reference(3), 3)
         self.assertEqual(
+            AudioCapture.normalize_device_reference({
+                'name': 'PipeWire ALSA [android-mic]',
+                'host_api': 'PipeWire',
+                'id': '7',
+            }),
+            {
+                'name': 'PipeWire ALSA [android-mic]',
+                'host_api': 'PipeWire',
+                'id': 7,
+            }
+        )
+        self.assertEqual(
             AudioCapture.normalize_device_reference('PipeWire ALSA [android-mic]'),
             'PipeWire ALSA [android-mic]'
         )
 
+    def test_resolve_input_device_reference_uses_stable_name_and_host_api(self):
+        with patch.object(AudioCapture, 'get_available_input_devices', return_value=[
+            {
+                'id': 2,
+                'name': 'PipeWire ALSA [android-mic]',
+                'host_api': 'PipeWire',
+                'reference': {'name': 'PipeWire ALSA [android-mic]', 'host_api': 'PipeWire'},
+                'display_name': 'PipeWire ALSA [android-mic] (PipeWire)',
+            },
+            {
+                'id': 8,
+                'name': 'PipeWire ALSA [android-mic]',
+                'host_api': 'PulseAudio',
+                'reference': {'name': 'PipeWire ALSA [android-mic]', 'host_api': 'PulseAudio'},
+                'display_name': 'PipeWire ALSA [android-mic] (PulseAudio)',
+            },
+        ]):
+            resolved = AudioCapture._resolve_input_device_reference({
+                'name': 'PipeWire ALSA [android-mic]',
+                'host_api': 'PipeWire',
+            })
+
+        self.assertIsNotNone(resolved)
+        self.assertEqual(resolved['id'], 2)
+
     @patch.object(AudioCapture, '_initialize_sounddevice', autospec=True, return_value=None)
     def test_set_device_none_switches_back_to_system_default(self, _mock_initialize):
-        capture = AudioCapture(device_id=5)
+        capture = AudioCapture(device_reference=5)
 
         with patch('src.audio_capture.sd') as mock_sd:
             mock_sd.default.device = [5, None]
@@ -53,20 +90,36 @@ class AudioCaptureDeviceSelectionTests(unittest.TestCase):
 
     @patch.object(AudioCapture, '_initialize_sounddevice', autospec=True, return_value=None)
     @patch.object(AudioCapture, '_ensure_supported_samplerate', autospec=True, return_value=None)
-    def test_set_device_accepts_stringified_device_ids(self, _mock_samplerate, _mock_initialize):
+    def test_set_device_accepts_stable_device_reference(self, _mock_samplerate, _mock_initialize):
         capture = AudioCapture()
 
         with patch('src.audio_capture.sd') as mock_sd:
             mock_sd.default.device = [None, None]
             mock_sd.query_devices.return_value = {
                 'name': 'PipeWire ALSA [android-mic]',
+                'hostapi': 0,
                 'max_input_channels': 1,
                 'default_samplerate': 48000,
             }
-
-            result = capture.set_device('7')
+            with patch.object(AudioCapture, 'get_available_input_devices', return_value=[
+                {
+                    'id': 7,
+                    'name': 'PipeWire ALSA [android-mic]',
+                    'host_api': 'PipeWire',
+                    'reference': {'name': 'PipeWire ALSA [android-mic]', 'host_api': 'PipeWire'},
+                    'display_name': 'PipeWire ALSA [android-mic] (PipeWire)',
+                }
+            ]):
+                result = capture.set_device({
+                    'name': 'PipeWire ALSA [android-mic]',
+                    'host_api': 'PipeWire',
+                })
 
         self.assertTrue(result)
+        self.assertEqual(capture.preferred_device, {
+            'name': 'PipeWire ALSA [android-mic]',
+            'host_api': 'PipeWire',
+        })
         self.assertEqual(capture.preferred_device_id, 7)
         self.assertEqual(capture.device_id, 7)
         self.assertEqual(capture.device_info['name'], 'PipeWire ALSA [android-mic]')


### PR DESCRIPTION
This change adds audio input device selection to the settings UI so WhisperTux can record from non-default sources, including PipeWire/ALSA inputs such as Android microphones.

It keeps the implementation narrow:

- exposes available input devices in the existing settings dialog
- validates the selected device before saving it
- applies the device to the running audio capture instance without requiring a restart
- normalizes legacy config values like "default" and stringified device IDs
- adds focused regression tests for device-reference normalization and switching

Why:

- fixes cases where PortAudio’s default input is not the source the user wants
- avoids persisting broken audio-device settings
- improves readability and alignment in the related settings rows without broader UI churn

Validation:

- python3 -m unittest discover -s tests
- python3 -m compileall main.py src tests
- git diff --check

Notes:

- linter tooling was not available in this environment
- If two input sources share the exact `name` and `host_api`, restore is still ambiguous.

